### PR TITLE
feat: add Windows jump list task for opening a new window

### DIFF
--- a/App/electron/main.js
+++ b/App/electron/main.js
@@ -554,6 +554,23 @@ app.whenReady().then(async () => {
   // Create the main window
   await createWindow();
 
+  if (process.platform === 'win32') {
+    app.setAppUserModelId(''); // empty app user model id to allow the jump list to be set correctly
+
+    app.setUserTasks([
+      {
+        program: process.execPath,
+        arguments: (isDev) ? __filename : '',
+        iconPath: path.join(__dirname, 'logo.png'),
+        iconIndex: 0,
+        title: 'New Window',
+        description: 'Open a new application window'
+      }
+    ]);
+
+    app.setAppUserModelId('com.pointer');
+  };
+
   autoUpdater.checkForUpdatesAndNotify();
 
   setInterval(() => {


### PR DESCRIPTION
### **Description of Change**

This PR adds a jump list task on Windows to allow users to open a new window directly from the taskbar.

* Uses `app.setUserTasks` to create a "New Window" option in the Windows taskbar context menu (jump list)
* Handles development vs production paths so the task launches correctly in both environments
* Ignored on macOS & Linux since jump lists are Windows-only

This improves user accessibility and provides a convenient way to launch multiple windows on Windows systems.

---

### **Release Notes**

**Windows:** Adds a Jump List task that allows opening a new window from the taskbar. Automatically handles dev and production environments.