### PR TITLE
fix: force sRGB color profile to correct screenshot colors

### DIFF
--- a/App/electron/main.js
+++ b/App/electron/main.js
@@ -548,6 +548,8 @@ async function createWindow() {
   }
 }
 
+app.commandLine.appendSwitch('force-color-profile', 'srgb');
+
 // This method will be called when Electron has finished initialization
 app.whenReady().then(async () => {
   console.log('Electron app is ready.');


### PR DESCRIPTION
### **Description of Change**

This PR forces the sRGB color profile in Electron to correct screenshot rendering issues across devices.

* Adds `app.commandLine.appendSwitch("force-color-profile", "srgb")` in the main process
* Ensures screenshots now correctly reflect colors regardless of device or display settings
* Addresses rendering inconsistencies previously observed on certain high-DPI or non-standard displays

This change improves the reliability and visual accuracy of screenshots taken within the app.

---

### **Release Notes**

Notes: Force sRGB color profile in Electron to fix incorrect screenshot colors across devices.